### PR TITLE
Update tile reference for semisolid (ID 16)

### DIFF
--- a/src/Drawers.cpp
+++ b/src/Drawers.cpp
@@ -903,7 +903,7 @@ void Drawers::DrawItem(const std::unordered_set<short>& K, bool L) {
 									H * Zm - (float)((level.MapObj[i].H - 0.5 + level.MapObj[i].Y / 160.0) * Zm), Zm,
 									Zm);
 							} else if(j == level.MapObj[i].W - 1) {
-								DrawTile(j2 + 1, 3, 1, 1, (float)((j - 0.5 + level.MapObj[i].X / 160.0) * Zm),
+								DrawTile(j2 + 2, 3, 1, 1, (float)((j - 0.5 + level.MapObj[i].X / 160.0) * Zm),
 									H * Zm - (float)((level.MapObj[i].H - 0.5 + level.MapObj[i].Y / 160.0) * Zm), Zm,
 									Zm);
 							} else {


### PR DESCRIPTION
Incorrect tile for the end of this semisolid.
Cross-referenced in JiXiaomai's original work (And I just happened to have a level that used a lot of these) https://github.com/JiXiaomai/SMM2LevelViewer/blob/b0b7c57a3c6b28160b1dda9c13ad9fd216217f91/Form1.vb#L1480

I'm in the process of making a golang version of this for fun (started with the JiXiaomai's but C++ is much easier to reason about). I may find more things like this so if you want me to hold off and have a larger PR rather than as I find things I understand.