### PR TITLE
Fix missing clear pipes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 
 CFLAGS := -std=gnu11
 CXXFLAGS := -std=gnu++2a -I./src
-CPPFLAGS := -Wall -Wextra -Wno-missing-field-initializers -Wno-deprecated-enum-enum-conversion
+CPPFLAGS := -Wall -Wextra -Wno-missing-field-initializers -Wno-deprecated-enum-enum-conversion -Wno-narrowing
 
 ifeq ($(BUILD),release)
 	# "Release" build - optimization, and no debug symbols

--- a/src/LevelData.hpp
+++ b/src/LevelData.hpp
@@ -1,6 +1,7 @@
 #include <cmath>
 #include <string>
 #include <unordered_map>
+#include <cstdint>
 
 namespace LevelData {
 	struct Sprite {

--- a/src/LevelParser.cpp
+++ b/src/LevelParser.cpp
@@ -149,8 +149,13 @@ void LevelParser::LoadLevelData(const std::string& levelData, bool overworld) {
 	}
 
 	MapCPipe.clear();
-	for(int i = 0; i < map.clear_pipe_count(); i++) {
+	for (size_t i = 0; i < map.clear_pipes()->size(); i++) {
 		auto& clear_pipe_ref = *map.clear_pipes()->at(i);
+		if (clear_pipe_ref.unk() == 0) {
+			// empty slot
+			continue;
+		}
+
 		LevelParser::MapClearPipe newClearPipe;
 		newClearPipe.Index     = clear_pipe_ref.index();
 		newClearPipe.NodeCount = clear_pipe_ref.node_count();


### PR DESCRIPTION
I noticed that clear pipes are sometimes missing from renders of certain levels.  I tracked this down to an oddity in the way that objects are laid out in the clear pipes array decoded by kaitai.  For example, consider level code `1FB-W58-1RF` and look at the very right side of the overworld.

```
./bin/toost -c 1FB-W58-1RF -o /tmp/overworld.png
```

Before:
![overworld-bugged](https://github.com/TheGreatRambler/toost/assets/385672/e4afe374-2e01-4021-81ef-3e68ab445138)

After:
![overworld](https://github.com/TheGreatRambler/toost/assets/385672/9014aae1-f235-4e98-8366-6f099d16b53c)

If you dump out all the clear pipe entries, you get this:

```
clear_pipe_count=86
index=0 unk=1
index=1 unk=1
index=2 unk=1
index=3 unk=1
index=4 unk=1
index=5 unk=1
index=6 unk=1
index=7 unk=1
index=8 unk=1                                     
index=0 unk=0                                     
index=10 unk=1                                                                                       
index=11 unk=1                                                                                       
index=12 unk=1                                                                                       
index=13 unk=1                                                                                       
index=14 unk=1                                                                                       
index=15 unk=1                                                                                       
index=16 unk=1                                                                                       
index=17 unk=1                                                                                       
index=0 unk=0                                                                                        
index=19 unk=1                                                                                       
index=20 unk=1  
index=21 unk=1
index=22 unk=1
index=23 unk=1
index=24 unk=1
index=25 unk=1
index=26 unk=1
index=27 unk=1
index=28 unk=1
index=29 unk=1
index=30 unk=1
index=31 unk=1
index=32 unk=1
index=33 unk=1
index=34 unk=1
index=35 unk=1
index=36 unk=1
index=37 unk=1
index=38 unk=1
index=39 unk=1
index=40 unk=1
index=41 unk=1
index=42 unk=1
index=43 unk=1
index=0 unk=0 
index=45 unk=1
index=46 unk=1
index=47 unk=1
index=48 unk=1
index=49 unk=1
index=50 unk=1
index=51 unk=1
index=52 unk=1
index=53 unk=1
index=54 unk=1
index=55 unk=1
index=56 unk=1
index=57 unk=1
index=58 unk=1
index=59 unk=1
index=60 unk=1
index=61 unk=1
index=62 unk=1
index=63 unk=1
index=64 unk=1
index=65 unk=1
index=66 unk=1
index=67 unk=1
index=68 unk=1
index=69 unk=1
index=70 unk=1
index=71 unk=1
index=72 unk=1
index=73 unk=1
index=74 unk=1
index=75 unk=1
index=76 unk=1
index=77 unk=1
index=78 unk=1
index=79 unk=1
index=80 unk=1
index=81 unk=1
index=82 unk=1
index=0 unk=0 
index=84 unk=1
index=85 unk=1
index=86 unk=1
index=87 unk=1
index=88 unk=1
index=89 unk=1
```

Notice that:
* Indexes 9, 18, 44, and 83 are missing from the output, and instead replaced by an empty pipe with index 0 and unk=0
* There are extra indexes 86, 87, 88, and 89 despite that `clear_pipe_count=86`.  These correspond to the 4 missing pipes above

I'm not sure exactly why this occurs, but I would guess maybe these pipes were deleted or moved or something.

I fixed this by always iterating the entire clear pipe array (ignoring `clear_pipe_count`) and instead discarding entries with `unk=0` and adding all other pipes to the clear pipe list.  As an aside, I had to tweak a few lines in unrelated places to get the code to compile on GCC 13.

**Note:** It's possible the same bug is present for piranha creepers, snake blocks, and similar array-count based objects, but I don't have any levels handy to test this.

