### PR TITLE
Draw Red Yoshi inside objects correctly

### DIFF
--- a/src/LevelDrawer.cpp
+++ b/src/LevelDrawer.cpp
@@ -3776,6 +3776,29 @@ void LevelDrawer::DrawCID() {
 			DrawImage(path, LX, LY, Zm, Zm);
 			DrawImage(LevelData::OBJ_CMN_F1, LX, LY, Zm, Zm);
 			break;
+		case 45: /* Yoshi & Shoe Goomba */ {
+			int variant;
+			switch(level.LH.GameStyle) {
+			case 21847 /* NSMBU */:
+			case 22349 /* SMW   */:
+				// Yoshi color -- unlike other objects handled by the top level
+				// default case, this is at 0x4000 instead of 0x4.
+				variant = (level.MapObj[i].CFlag & 0x4000) == 0x4000;
+				break;
+			default /* SMB1, SMB3 */:
+				// Regular vs. stiletto shoe
+				variant = (level.MapObj[i].CFlag & 0x4   ) == 0x4;
+				break;
+			}
+			if(variant) {
+				path = LevelData::GetIndex(level.LH.GameStyle, objCid, LevelData::A_, LevelData::CID);
+			} else {
+				path = LevelData::GetIndex(level.LH.GameStyle, objCid, LevelData::NONE, LevelData::CID);
+			}
+			DrawImage(path, LX, LY, Zm, Zm);
+			DrawImage(LevelData::OBJ_CMN_F1, LX, LY, Zm, Zm);
+			break;
+		}
 		default:
 			if((level.MapObj[i].CFlag / 0x4) % 2 == 1) {
 				path = LevelData::GetIndex(level.LH.GameStyle, objCid, LevelData::A_, LevelData::CID);


### PR DESCRIPTION
Yoshi uses a different flag for its variant so it needs to be handled specially.  Also, since Yoshi and Shoe Goomba are the same object, we must preserve the drawing behavior for Shoe Goomba depending on the gamestyle.

Test case: GDH-724-CFF

Expected output:
<img width="2608" height="432" alt="o" src="https://github.com/user-attachments/assets/9f4e8d03-e16a-487c-81e2-78941cf73e29" />
